### PR TITLE
Remove Deprication To Modern JS

### DIFF
--- a/src/Assertion.js
+++ b/src/Assertion.js
@@ -48,10 +48,11 @@ module.exports = function(secret, asserts) {
       headers: res.headers,
       cookies: []
     };
-
+    
     // build assertions request object
     if (request.headers.cookie) {
-      request.headers.cookie.split(/; */).forEach(function(cookie) {
+      const cookies =  String(request.headers.cookie)
+      cookies.split(/; */).forEach(function(cookie) {
         request.cookies.push(Assertion.parse(cookie));
       });
     }

--- a/src/Assertion.js
+++ b/src/Assertion.js
@@ -40,7 +40,7 @@ module.exports = function(secret, asserts) {
 
     // request and response object initialization
     var request = {
-      headers: res.req._headers,
+      headers: res.req.getHeaders(),
       cookies: []
     };
 


### PR DESCRIPTION
change _header to .getHeader()

force Cast Cookie string to String 