### PR TITLE
Correct documentation for `.renew`

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Assert that cookie is set and was NOT already set (NOT in request headers).
 
 ### .renew(expects, [assert])
 
-Assert that cookie is set with a "greater than" or "equal to" `expires` or `max-age` than was already set.
+Assert that cookie is set with a strictly greater `expires` or `max-age` than the given value.
 
 *Arguments*
 

--- a/test/ExpectCookies.js
+++ b/test/ExpectCookies.js
@@ -273,7 +273,7 @@ describe('Cookies', function() {
   });
 
   describe('.renew', function() {
-    it('asserts true if cookie expiration is greater than already set cookie', function(done) {
+    it('asserts true if cookie expiration is greater than expected', function(done) {
       var expires = new Date();
       var expiresRenewed = new Date(expires.getTime() + 60000);
 
@@ -304,7 +304,7 @@ describe('Cookies', function() {
         .end(done);
     });
 
-    it('asserts false if cookie expiration is less than or equal to already set cookie', function(done) {
+    it('asserts false if cookie expiration is less than expected', function(done) {
       var expires = new Date();
       var expiresRenewed = new Date(expires.getTime() - 60000);
 
@@ -335,7 +335,7 @@ describe('Cookies', function() {
         .end(done);
     });
 
-    it('asserts true if cookie max-age is greater than already set cookie', function(done) {
+    it('asserts true if cookie max-age is greater than expected', function(done) {
       var app = express();
 
       app.use(cookieParser(secrets));
@@ -363,7 +363,7 @@ describe('Cookies', function() {
         .end(done);
     });
 
-    it('asserts false if cookie max-age is less than or equal to already set cookie', function(done) {
+    it('asserts false if cookie max-age is less than or equal to expected', function(done) {
       var app = express();
 
       app.use(cookieParser(secrets));


### PR DESCRIPTION
README says it checks against the request cookie, but actually it checks
against the `expects` object. Also, it checks for strictly greater, not
greater or equal.

Fixes #3 