### PR TITLE
Fix type conversions for max-age

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Assert that cookie is set with a "greater than" or "equal to" `expires` or `max-
   - `name` - String name of cookie.
   - `options` - Object of options. `use one of two options below`
    - `options`.`expires` - String UTC expiration for original cookie (in request headers).
-   - `options`.`max-age` - Integer ttl for original cookie (in request headers).
+   - `options`.`max-age` - Integer ttl in seconds for original cookie (in request headers).
 - `assert` - *Optional* boolean "assert true" modifier. Default: `true`.
 
 ### .contain(expects, [assert])
@@ -139,7 +139,7 @@ Requires `Cookies(secret)` initialization if cookie is signed.
    - `options`.`domain` - *Optional* string domain.
    - `options`.`path` - *Optional* string path.
    - `options`.`expires` - *Optional* string UTC expiration.
-   - `options`.`max-age` - *Optional* integer ttl.
+   - `options`.`max-age` - *Optional* integer ttl, in seconds.
    - `options`.`secure` - *Optional* boolean secure flag.
    - `options`.`httponly` - *Optional* boolean httpOnly flag.
 - `assert` - *Optional* boolean "assert true" modifier. Default: `true`.

--- a/src/Assertion.js
+++ b/src/Assertion.js
@@ -48,7 +48,7 @@ module.exports = function(secret, asserts) {
       headers: res.headers,
       cookies: []
     };
-    
+
     // build assertions request object
     if (request.headers.cookie) {
       const cookies =  String(request.headers.cookie)
@@ -336,8 +336,13 @@ module.exports = function(secret, asserts) {
         }
 
         keys.forEach(function(key) {
-          if (assert) should(cookie.options[key]).be.eql(expect.options[key]);
-          else should(cookie.options[key]).not.be.eql(expect.options[key]);
+          const expected = (
+            key === 'max-age'
+              ? expect.options[key].toString()
+              : expect.options[key]
+          );
+          if (assert) should(cookie.options[key]).be.eql(expected);
+          else should(cookie.options[key]).not.be.eql(expected);
         });
       });
     });

--- a/test/ExpectCookies.js
+++ b/test/ExpectCookies.js
@@ -493,6 +493,36 @@ describe('Cookies', function() {
         .end(done);
     });
 
+    it('handles type conversion for max-age', function(done) {
+      var app = express();
+
+      app.use(cookieParser(secrets));
+
+      app.get('/', function (req, res) {
+        res.cookie('substance', 'active', {domain: 'domain.com', maxAge: 60000});
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo')
+        .expect(function (res) {
+          var assertion = Cookies(secrets).contain({
+            'name': 'substance',
+            'value': 'active',
+            'options': {
+              'domain': 'domain.com',
+              'max-age': 60
+            }
+          });
+
+          should(function () {
+            assertion(res);
+          }).not.throw();
+        })
+        .end(done);
+    });
+
     it('asserts false if cookie does NOT exist', function(done) {
       var expires = new Date();
 


### PR DESCRIPTION
Docs call for a numeric TTL but no conversion was done, resulting in
failed comparisons.

Fixes #4 