### PR TITLE
Fix optionality of .contain({ value })

### DIFF
--- a/src/Assertion.js
+++ b/src/Assertion.js
@@ -318,21 +318,23 @@ module.exports = function(secret, asserts) {
         if (!cookie) throw new Error('expected: ' + expect.name + ' cookie to be set');
 
         // check cookie values are equal
-        try {
-          if (assert) should(cookie.value).be.eql(expect.value);
-          else should(cookie.value).not.be.eql(expect.value);
-        } catch(e) {
-          if (secret.length) {
-            var value;
-            secret.every(function(sec) {
-              value = signature.unsign(cookie.value.slice(2), sec);
-              return !(value && value === expect.value);
-            });
+        if ('value' in expect) {
+          try {
+            if (assert) should(cookie.value).be.eql(expect.value);
+            else should(cookie.value).not.be.eql(expect.value);
+          } catch(e) {
+            if (secret.length) {
+              var value;
+              secret.every(function(sec) {
+                value = signature.unsign(cookie.value.slice(2), sec);
+                return !(value && value === expect.value);
+              });
 
-            if (assert && !value) throw new Error('expected: ' + expect.name + ' value to equal ' + expect.value);
-            else if (!assert && value) throw new Error('expected: ' + expect.name + ' value to NOT equal ' + expect.value);
+              if (assert && !value) throw new Error('expected: ' + expect.name + ' value to equal ' + expect.value);
+              else if (!assert && value) throw new Error('expected: ' + expect.name + ' value to NOT equal ' + expect.value);
+            }
+            else throw e;
           }
-          else throw e;
         }
 
         keys.forEach(function(key) {

--- a/test/ExpectCookies.js
+++ b/test/ExpectCookies.js
@@ -493,6 +493,33 @@ describe('Cookies', function() {
         .end(done);
     });
 
+    it('allows any value if omitted from expects object', function(done) {
+
+      var app = express();
+      app.use(cookieParser(secrets));
+      app.get('/', function (req, res) {
+        res.cookie('substance', 'active', {domain: 'domain.com'});
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo')
+        .expect(function (res) {
+          var assertion = Cookies(secrets).contain({
+            'name': 'substance',
+            'options': {
+              'domain': 'domain.com',
+            },
+          });
+
+          should(function () {
+            assertion(res);
+          }).not.throw();
+        })
+        .end(done);
+    });
+
     it('asserts false if cookie does NOT exist', function(done) {
       var expires = new Date();
 


### PR DESCRIPTION
Docs state value is optional, but it was actually checked unconditionally.

Fixes #5.